### PR TITLE
Default to empty hash when fetching gem installer options

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -23,7 +23,7 @@ if defined?( JRUBY_VERSION ) && Gem.post_install_hooks.empty?
   Gem.post_install do |gem_installer|
     require 'jar_installer'
     jars = Jars::JarInstaller.new( gem_installer.spec )
-    jars.ruby_maven_install_options = gem_installer.options 
+    jars.ruby_maven_install_options = gem_installer.options || {}
     jars.vendor_jars
   end
 end


### PR DESCRIPTION
I was seeing `TypeError: can't dup NilClass` when running `jbundle` because `Gem.post_install` was yielding a `gem_installer` whose `options` were `nil`. Later on, this `nil` was getting passed to `Jars::JarInstaller::Dependency` via `ruby_maven_install_options=`, which calls `dup` on the nil options. This pull request defaults the options to an empty hash.
