### PR TITLE
Simplify impl of home

### DIFF
--- a/lib/jar_dependencies.rb
+++ b/lib/jar_dependencies.rb
@@ -149,22 +149,10 @@ module Jars
     end
 
     def home
-      if ( @_jars_home_ ||= nil ).nil?
-        unless @_jars_home_ = absolute( to_prop( HOME ) )
-          begin
-            if user_settings = maven_user_settings
-              @_jars_home_ = detect_local_repository(user_settings)
-            end
-            if ! @_jars_home_ && global_settings = maven_global_settings
-              @_jars_home_ = detect_local_repository(global_settings)
-            end
-          rescue # ignore
-          end
-        end
-        # use maven default repository
-        @_jars_home_ ||= File.join( user_home, '.m2', 'repository' )
-      end
-      @_jars_home_
+      @_jars_home_ ||= absolute(to_prop(HOME)) ||
+                       detect_local_repository(maven_user_settings) ||
+                       detect_local_repository(maven_global_settings) ||
+                       File.join( user_home, '.m2', 'repository' )
     end
 
     def require_jars_lock!( scope = :runtime )
@@ -227,6 +215,8 @@ module Jars
     end
 
     def detect_local_repository(settings)
+      return nil unless settings
+      
       doc = File.read( settings )
       # TODO filter out xml comments
       local_repo = doc.sub( /<\/localRepository>.*/m, '' ).sub( /.*<localRepository>/m, '' )


### PR DESCRIPTION
This makes two changes to consider:

1. if is not blanket rescuing in home.  No test fails removing it so I guess I am curious which case needs the rescue
1. detect_local_repository returns nil if it receives settings with a value of nil which does not change contract but does widen acceptable values to that method (before this PR it would throw an ArgumentError because nil is not a String).