### PR TITLE
add test for vendor_jars example

### DIFF
--- a/specs/jar_installer_spec.rb
+++ b/specs/jar_installer_spec.rb
@@ -113,4 +113,8 @@ describe Jars::Installer do
     end
     ENV[ 'JARS_HOME' ] = nil
   end
+
+  it 'tests default vendor_jars task' do
+    Jars::JarInstaller.vendor_jars
+  end
 end


### PR DESCRIPTION
This will test the vendor_jars call found in the [README.md](https://github.com/mkristian/jar-dependencies#vendoring-your-jars-before-packing-the-jar).