### PR TITLE
avoid circular require

### DIFF
--- a/lib/jar_dependencies.rb
+++ b/lib/jar_dependencies.rb
@@ -18,7 +18,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require 'jars/maven_settings'
+
 module Jars
   unless defined? Jars::SKIP_LOCK
     MAVEN_SETTINGS = 'JARS_MAVEN_SETTINGS'.freeze
@@ -46,6 +46,8 @@ module Jars
     # vendor jars inside gem when installing gem
     VENDOR = 'JARS_VENDOR'.freeze
   end
+
+  autoload :MavenSettings, 'jars/maven_settings'
 
   class << self
 

--- a/lib/jars/maven_settings.rb
+++ b/lib/jars/maven_settings.rb
@@ -1,4 +1,3 @@
-require 'jar_dependencies'
 require 'rubygems/request'
 require 'rubygems/uri_formatter'
 module Jars
@@ -127,7 +126,7 @@ module Jars
           raw.sub!('__HTTP_SERVER__', http.host)
           raw.sub!('__HTTP_PORT__', http.port.to_s)
         else
-          raw.sub!('__HTTP_ACTIVE__', 'false')    
+          raw.sub!('__HTTP_ACTIVE__', 'false')
         end
         if https
           raw.sub!('__HTTPS_ACTIVE__', 'true')


### PR DESCRIPTION
would be a nice improvement not to see a circular require warning in verbose mode e.g. 

`jruby -v -S gem install rake`

```
jruby 9.1.7.0 (2.3.1) 2017-01-11 68056ae Java HotSpot(TM) 64-Bit Server VM 25.112-b15 on 1.8.0_112-b15 +jit [linux-x86_64]
/opt/local/rvm/gems/jruby-9.1.7.0@global/gems/executable-hooks-1.3.2/lib/executable-hooks/regenerate_binstubs_command.rb:58: warning: shadowing outer local variable - path
/opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55: warning: loading in progress, circular require considered harmful - /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/jar_dependencies.rb
          require at org/jruby/RubyKernel.java:961
          require at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/jars/maven_settings.rb:1
          require at org/jruby/RubyKernel.java:961
           (root) at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
          require at org/jruby/RubyKernel.java:961
           (root) at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/jar_dependencies.rb:21
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
          require at org/jruby/RubyKernel.java:961
          require at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/jar-dependencies.rb:22
          require at org/jruby/RubyKernel.java:961
           (root) at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
          require at org/jruby/RubyKernel.java:961
           (root) at /opt/local/rvm/gems/jruby-9.1.7.0@global/gems/jruby-openssl-0.9.19-java/lib/jopenssl/load.rb:11
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
          require at org/jruby/RubyKernel.java:961
          require at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
           <main> at /opt/local/rvm/gems/jruby-9.1.7.0@global/gems/jruby-openssl-0.9.19-java/lib/openssl.rb:1
          require at org/jruby/RubyKernel.java:961
           (root) at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
          require at org/jruby/RubyKernel.java:961
           (root) at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/security.rb:12
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
          require at org/jruby/RubyKernel.java:961
          require at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/package.rb:44
             load at org/jruby/RubyKernel.java:979
  block in (root) at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
             each at org/jruby/RubyArray.java:1733
          require at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
           (root) at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/installer.rb:10
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
          require at org/jruby/RubyKernel.java:961
          require at /opt/local/rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55
           <main> at /opt/local/rvm/gems/jruby-9.1.7.0@global/gems/executable-hooks-1.3.2/lib/executable-hooks/regenerate_binstubs_command.rb:2
             load at org/jruby/RubyKernel.java:979
           <main> at /opt/local/rvm/rubies/jruby-9.1.7.0/bin/gem:4
Fetching: rake-12.0.0.gem (100%)
...
```