### PR TITLE
Fix code style for generated <gem>_jars.rb file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - GOAL='verify -Dmaven.test.skip -Dinvoker.test=*,!install*,!gemspecs'
 jdk:
   - openjdk7
-  - oraclejdk7
+  - openjdk8
   - oraclejdk8
 install: ./mvnw initialize
 script: ./mvnw $GOAL

--- a/lib/jars/installer.rb
+++ b/lib/jars/installer.rb
@@ -67,7 +67,7 @@ module Jars
     def self.install_jars( write_require_file = false )
       new.install_jars( write_require_file )
     end
-    
+
     def self.load_from_maven( file )
       result = []
       File.read( file ).each_line do |line|
@@ -105,12 +105,12 @@ module Jars
     def self.print_require_jar( file, dep, fallback = false )
       return if dep.type != :jar || dep.scope != :runtime
       if dep.system?
-        file.puts( "require( '#{dep.file}' )" ) if file
+        file.puts("require '#{dep.file}'") if file
       elsif dep.scope == :runtime
         if fallback
-          file.puts( "  require '#{dep.path}'" ) if file
+          file.puts("  require '#{dep.path}'") if file
         else
-          file.puts( "  require_jar( '#{dep.gav.gsub( ':', "', '" )}' )" ) if file
+          file.puts("  require_jar '#{dep.gav.gsub( ':', "', '" )}'") if file
         end
       end
     end

--- a/specs/jar_installer_spec.rb
+++ b/specs/jar_installer_spec.rb
@@ -42,7 +42,7 @@ describe Jars::Installer do
     Jars::Installer.install_deps( deps, dir, jars, false )
     File.read( jars ).each_line do |line|
       if line.size > 30 && !line.match( /^#/ )
-        line.match( /^  require(_jar\(| )/ ).wont_be_nil
+        line.must_match /^\s{2}require(_jar)?\s'.+'$/
       end
     end
     Dir[ File.join( dir, '**' ) ].size.must_equal 1
@@ -53,7 +53,7 @@ describe Jars::Installer do
     Jars::Installer.install_deps( deps, dir, jars, true )
     File.read( jars ).each_line do |line|
       if line.size > 30 && !line.match( /^#/ )
-        line.match( /^  require(_jar\(| )/ ).wont_be_nil
+        line.must_match /^\s{2}require(_jar)?\s'.+'$/
       end
     end
     Dir[ File.join( dir, '**', '*.jar' ) ].size.must_equal 45


### PR DESCRIPTION
Fixes #61.

I just removed the parentheses for all `require` and `require_jar` calls to keep it consistent and extended the regexes in the tests to match the full line.