### PR TITLE
use JRuby::Util (available since 1.7) instead of JRuby.runtime

### DIFF
--- a/lib/jar_dependencies.rb
+++ b/lib/jar_dependencies.rb
@@ -136,7 +136,11 @@ module Jars
 
     def jars_lock_from_class_loader
       if to_prop(LOCK).nil? && defined?(JRUBY_VERSION)
-        JRuby.runtime.jruby_class_loader.get_resources('Jars.lock').collect(&:to_s)
+        if JRuby::Util.respond_to?(:class_loader_resources)
+          JRuby::Util.class_loader_resources('Jars.lock')
+        else; require 'jruby'
+          JRuby.runtime.jruby_class_loader.get_resources('Jars.lock').collect(&:to_s)
+        end
       end
     end
 


### PR DESCRIPTION
... however `class_loader_resources` is only there since 9.2
still this helps, when embedded, into 9.2 stdlib to load faster

WiP on JRuby's end atm ... 