### PR TITLE
Fix warning

### DIFF
--- a/lib/jars/installer.rb
+++ b/lib/jars/installer.rb
@@ -45,7 +45,7 @@ module Jars
         parts << artifact_id
         parts << second.split(':')[-1]
         @file = line.slice(@coord.length, line.length).sub(REG, EMPTY).strip
-        last = @file.reverse.index /\\|\//
+        last = @file.reverse.index(/\\|\//)
         parts << line[-last..-1]
         @path = File.join(parts).strip
 


### PR DESCRIPTION
I'm working on getting rubygems tests to pass under jruby and I'm getting this warning ~all over the place~ once

```
/home/deivid/.rbenv/versions/jruby-9.2.7.0/lib/ruby/stdlib/jars/installer.rb:48: warning: Ambiguous first argument; make sure.
```

This change should fix it.