### PR TITLE
Fix incorrect gemspec path gem installing default gems

### DIFF
--- a/lib/jars/maven_exec.rb
+++ b/lib/jars/maven_exec.rb
@@ -38,9 +38,9 @@ module Jars
           spec = eval(File.read(@specfile), TOPLEVEL_BINDING, @specfile)
         end
       when Gem::Specification
-        if File.exist?(spec.spec_file)
+        if File.exist?(spec.loaded_from)
           @basedir = spec.gem_dir
-          @specfile = spec.spec_file
+          @specfile = spec.loaded_from
         else
           # this happens with bundle and local gems
           # there the spec_file is "not installed" but inside


### PR DESCRIPTION
When running rubygems tests against `jruby`, we get a lot of warnings coming from `jar-dependencies`. See the output of a test run on jruby:

```
$ rake
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/jruby-openssl-0.10.5.dev-java/lib/jopenssl.jar) to constructor java.security.KeyFactory(java.security.KeyFactorySpi,java.security.Provider,java.lang.String)
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Skipping `gem cert` tests on jruby.
Skipping Gem::Security tests on jruby.
Run options: --seed 59820

# Running:

.../home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/stdlib/jars/installer.rb:48: warning: Ambiguous first argument; make sure.
.............................................................................S.....S.........................................................................................................................................................................................................................................................../home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
................/home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
........................../home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
.............................................................................................................................................................jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
..................................................S...................................................jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/b-2
.....................S..................................S....................................................S.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/gemhome/gems/a-1
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/gemhome/gems/a-1
jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/gemhome/gems/a-1
..............jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2.0.0.0
...S..S.S.......................................................................................................................................S.........................S.........................../home/deivid/Code/rubygems/lib/rubygems/util.rb:61: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
/home/deivid/Code/rubygems/lib/rubygems/util.rb:61: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
......................jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/a-1
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/a-1-java
...jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/a-1
...................S........................................................................................S............S..........S.......S.S............S..........................................................................S.......................................S................................................................................................................................S.SS.......................................................................................................................................................................................................S......................................S.................S....................S........................................S..S...........S.............S........................................S.............S..................................................................................S...S........S............................................................................................................................

Finished in 280.222738s, 7.2228 runs/s, 21.9611 assertions/s.

2024 runs, 6154 assertions, 0 failures, 0 errors, 36 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/coverage. 7600 / 9185 LOC (82.74%) covered.
```

The problem happens only when installing default gems. In that case, the path to the gemspec is different. The installer has a `spec.loaded_from` method though that takes the type of gem into account and always provides a valid path to the proper gemspec:

https://github.com/rubygems/rubygems/blob/ab415609bb6d19da4593b70fd9da42f3c0bbc6fb/lib/rubygems/installer.rb#L298-L303 