### PR TITLE
adjust gem post install hook to allow updating the default gem

### DIFF
--- a/lib/jar_install_post_install_hook.rb
+++ b/lib/jar_install_post_install_hook.rb
@@ -18,4 +18,10 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require 'jars/post_install_hook'
+
+if defined?(JRUBY_VERSION) && Gem.post_install_hooks.empty?
+  Gem.post_install do |gem_installer|
+    require "jars/post_install_hook"
+    Jars.post_install_hook(gem_installer)
+  end
+end

--- a/lib/jars/post_install_hook.rb
+++ b/lib/jars/post_install_hook.rb
@@ -19,13 +19,13 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-if defined?(JRUBY_VERSION) && Gem.post_install_hooks.empty?
-  Gem.post_install do |gem_installer|
-    unless (ENV['JARS_SKIP'] || ENV_JAVA['jars.skip']) == 'true'
-      require 'jars/installer'
-      jars = Jars::Installer.new(gem_installer.spec)
-      jars.ruby_maven_install_options = gem_installer.options || {}
-      jars.vendor_jars
-    end
+module Jars
+  def self.post_install_hook(gem_installer)
+    return if (ENV["JARS_SKIP"] || ENV_JAVA["jars.skip"]) == "true"
+
+    require "jars/installer"
+    jars = Jars::Installer.new(gem_installer.spec)
+    jars.ruby_maven_install_options = gem_installer.options || {}
+    jars.vendor_jars
   end
 end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -18,4 +18,5 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require 'jars/post_install_hook'
+
+require "jar_install_post_install_hook"


### PR DESCRIPTION
see https://github.com/jruby/jruby/issues/7262

rubygems/defaults/jruby.rb needs to _not_ require a file from
jar-dependencies when it first runs, otherwise bundler can't
load a version of jar-dependencies that's installed later.
this commit is intended to have jruby.rb register the
post-install hook itself, and therefore defer loading
jar-dependencies until it's actually needed. jruby needs
an update for its defaults to match the new
jar_install_post_install_hook.rb. in the meantime, this
commit is compatible with the current defaults or an
updated one.