### PR TITLE
Revert "adjust gem post install hook to allow updating the default gem"

### DIFF
--- a/lib/jar_install_post_install_hook.rb
+++ b/lib/jar_install_post_install_hook.rb
@@ -20,10 +20,4 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-
-if defined?(JRUBY_VERSION) && Gem.post_install_hooks.empty?
-  Gem.post_install do |gem_installer|
-    require 'jars/post_install_hook'
-    Jars.post_install_hook(gem_installer)
-  end
-end
+require 'jars/post_install_hook'

--- a/lib/jars/post_install_hook.rb
+++ b/lib/jars/post_install_hook.rb
@@ -21,13 +21,13 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-module Jars
-  def self.post_install_hook(gem_installer)
-    return if (ENV['JARS_SKIP'] || ENV_JAVA['jars.skip']) == 'true'
-
-    require 'jars/installer'
-    jars = Jars::Installer.new(gem_installer.spec)
-    jars.ruby_maven_install_options = gem_installer.options || {}
-    jars.vendor_jars
+if defined?(JRUBY_VERSION) && Gem.post_install_hooks.empty?
+  Gem.post_install do |gem_installer|
+    unless (ENV['JARS_SKIP'] || ENV_JAVA['jars.skip']) == 'true'
+      require 'jars/installer'
+      jars = Jars::Installer.new(gem_installer.spec)
+      jars.ruby_maven_install_options = gem_installer.options || {}
+      jars.vendor_jars
+    end
   end
 end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -20,5 +20,4 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-
-require 'jar_install_post_install_hook'
+require 'jars/post_install_hook'


### PR DESCRIPTION
This reverts commit 006fb2545bd11183612a85526c0891055653472a.

While the patch provided by @ccutrer did make jar-dependencies upgradable, it also caused a hard break in compatibility with earlier JRuby versions and had to eventually be reversed (jar-dependencies 0.4.2 yanked, changes to JRuby reverted). This closes the loop and reverts the changes in jar-dependencies, so we can go forward with compatible changes for now.
