### PR TITLE
Relocate maven extensions

### DIFF
--- a/lib/jars/.mvn/extensions.xml
+++ b/lib/jars/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>io.takari.polyglot</groupId>
+    <artifactId>polyglot-ruby</artifactId>
+    <version>0.1.18</version>
+  </extension>
+</extensions>


### PR DESCRIPTION
Maven was fixed in https://github.com/apache/maven/pull/94 to only search the target pom's directory structure for .mvn when passing -f to indicate a specific pom file. Unfortunately that breaks logic in ruby-maven intended to temporarily copy the .mvn/extensions.xml file to the current directory to enable Polyglot Ruby poms. This in turn breaks jar-dependencies when running with newer ruby-maven-libs at the root of the filesystem, for reasons described in https://github.com/jruby/jar-dependencies/issues/90:

https://github.com/jruby/jar-dependencies/issues/90

This is a possible workaround, by putting the extension config in the same dir as the files we want to treat as Polyglot Ruby pom scripts. It does not fix the underlying problem with ruby-maven.