### PR TITLE
Update calls to lock_down methods

### DIFF
--- a/exe/lock_jars
+++ b/exe/lock_jars
@@ -51,4 +51,4 @@ optparse = OptionParser.new do |opts|
 end
 optparse.parse!
 
-Jars.lock_down(options[:debug], options[:verbose], options)
+Jars.lock_down(debug: options.delete(:debug), verbose: options.delete(:verbose), **options)

--- a/lib/jar_dependencies.rb
+++ b/lib/jar_dependencies.rb
@@ -61,7 +61,7 @@ module Jars
     def lock_down(debug: false, verbose: false, **kwargs)
       ENV[SKIP_LOCK] = 'true'
       require 'jars/lock_down' # do this lazy to keep things clean
-      Jars::LockDown.new(debug, verbose).lock_down(**kwargs)
+      Jars::LockDown.new(debug, verbose).lock_down(kwargs.delete(:vendor_dir), **kwargs)
     ensure
       ENV[SKIP_LOCK] = nil
     end


### PR DESCRIPTION
Changed for 0.5.2 but not propagated to consumers.

* verbose and debug kwargs need to be pulled out of options in lock_jars script before calling jar_dependencies.rb's lock_down method.
* vendor_dir kwarg needs to be pulled out in jar_dependencies.rb when calling lock_down.rb's lock_down method.

See jruby/jruby#8509