### PR TITLE
[build] upgrade/fix rubocop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,5 @@ jobs:
       - name: Run test
         run: jruby -Ilib -rbundler/setup -S rake specs
       - name: Run RuboCop
-        run: jruby -Ilib -rbundler/setup -S rubocop lib
+        if: matrix.ruby-version == 'jruby-10.0' # Only run RuboCop on modern JRuby; target older jrubies via .rubocop.yml
+        run: jruby -Ilib -rbundler/setup -S rubocop lib specs

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
-require:
+plugins:
   - rubocop-rake
   - rubocop-performance
+  - rubocop-minitest
 
 AllCops:
   TargetRubyVersion: 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ group :development do
   gem 'rake', require: false
   gem 'ruby-debug', '~> 0.11', require: false
 
-  gem 'rubocop', '~> 1.50.0', require: false
+  gem 'rubocop', require: false
+  gem 'rubocop-minitest', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rake', require: false
 end

--- a/lib/jar_dependencies.rb
+++ b/lib/jar_dependencies.rb
@@ -95,7 +95,7 @@ module Jars
       if @require.nil?
         if (require = to_boolean(REQUIRE)).nil?
           no_require = to_boolean(NO_REQUIRE)
-          @require = no_require.nil? ? true : !no_require
+          @require = no_require.nil? || !no_require
         else
           @require = require
         end

--- a/lib/jars/gemspec_artifacts.rb
+++ b/lib/jars/gemspec_artifacts.rb
@@ -12,7 +12,7 @@ module Jars
           if low == high
             low
           else
-            super "#{low || '[0'},#{high || ')'}"
+            super("#{low || '[0'},#{high || ')'}")
           end
         end
       end
@@ -26,17 +26,17 @@ module Jars
           ["[#{snapshot_version(val)}", "#{snapshot_version(last)}]"]
         elsif arg.include?('>=')
           val = arg.sub(/>=\s*/, '')
-          ["[#{snapshot_version(val)}", (nil || high)]
+          ["[#{snapshot_version(val)}", high]
         elsif arg.include?('<=')
           val = arg.sub(/<=\s*/, '')
-          [(nil || low), "#{snapshot_version(val)}]"]
+          [low, "#{snapshot_version(val)}]"]
         # treat '!' the same way as '>' since maven can not describe such range
         elsif /[!>]/.match?(arg)
           val = arg.sub(/[!>]\s*/, '')
-          ["(#{snapshot_version(val)}", (nil || high)]
+          ["(#{snapshot_version(val)}", high]
         elsif arg.include?('<')
           val = arg.sub(/<\s*/, '')
-          [(nil || low), "#{snapshot_version(val)})"]
+          [low, "#{snapshot_version(val)})"]
         elsif arg.include?('=')
           val = arg.sub(/=\s*/, '')
           # for prereleased version pick the maven version (no version range)
@@ -133,12 +133,12 @@ module Jars
 
         if /[\[()\]]/.match?(line)
           index = line.index(/[\[(].+$/)
-          version = line[index..].sub(/:/, ', ')
-          line = line[0..index - 1].strip.sub(/:$/, '')
+          version = line[index..].sub(':', ', ')
+          line = line[0..(index - 1)].strip.sub(/:$/, '')
         else
           index = line.index(/:[^:]+$/)
-          version = line[index + 1..]
-          line = line[0..index - 1].strip
+          version = line[(index + 1)..]
+          line = line[0..(index - 1)].strip
         end
 
         case line.count(':')

--- a/lib/jars/gemspec_pom.rb
+++ b/lib/jars/gemspec_pom.rb
@@ -4,7 +4,7 @@
 
 def eval_file(file)
   file = File.join(__dir__, file)
-  eval(File.read(file), nil, file)  # rubocop:disable Security/Eval
+  eval(File.read(file), nil, file) # rubocop:disable Security/Eval
 end
 
 eval_file('attach_jars_pom.rb')

--- a/lib/jars/lock.rb
+++ b/lib/jars/lock.rb
@@ -57,7 +57,7 @@ module Jars
       File.read(@file).each_line do |line|
         next unless /:.+:/.match?(line)
 
-        jar = JarDetails.new(line.strip.sub(/:jar:/, ':').sub(/:$/, ': ').split(':'))
+        jar = JarDetails.new(line.strip.sub(':jar:', ':').sub(/:$/, ': ').split(':'))
         case scope
         when :all, :test
           yield jar

--- a/lib/jars/lock_down.rb
+++ b/lib/jars/lock_down.rb
@@ -44,7 +44,7 @@ module Jars
       Bundler.setup('default')
       maven.property('jars.bundler', true)
       cwd = File.expand_path('.')
-      Gem.loaded_specs.each do |_name, spec|
+      Gem.loaded_specs.each_value do |spec|
         # if gemspec is local then include all dependencies
         maven.attach_jars(spec, all_dependencies: cwd == spec.full_gem_path)
       end

--- a/lib/jars/output_jars_pom.rb
+++ b/lib/jars/output_jars_pom.rb
@@ -5,7 +5,7 @@
 if ENV_JAVA['jars.quiet'] != 'true'
   model.dependencies.each do |d|
     puts "      #{d.group_id}:#{d.artifact_id}" \
-         "#{d.classifier ? ":#{d.classifier}" : ''}" \
+         "#{":#{d.classifier}" if d.classifier}" \
          ":#{d.version}:#{d.scope || 'compile'}"
     next if d.exclusions.empty?
 

--- a/specs/classpath_spec.rb
+++ b/specs/classpath_spec.rb
@@ -142,22 +142,23 @@ describe Jars::Classpath do
   it 'resolves classpath_string from gemspec' do
     ENV_JAVA['jars.quiet'] = 'true'
     Dir.chdir(File.dirname(example_spec)) do
-      _(Helper.prepare(subject.classpath_string.split(File::PATH_SEPARATOR))).must_equal Helper.prepare(example_expected)
+      _(Helper.prepare(subject.classpath_string.split(File::PATH_SEPARATOR)))
+        .must_equal Helper.prepare(example_expected)
 
       _(Helper.prepare(subject.classpath_string(:compile).split(File::PATH_SEPARATOR)))
-            .must_equal Helper.prepare(
-              expected_with_bc + ['org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar']
-            )
+        .must_equal Helper.prepare(
+          expected_with_bc + ['org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar']
+        )
 
       _(Helper.prepare(subject.classpath_string(:test).split(File::PATH_SEPARATOR)))
-            .must_equal Helper.prepare(expected_with_bc + [
-              'junit/junit/4.12/junit-4.12.jar',
-              'org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar',
-              'org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar'
-            ])
+        .must_equal Helper.prepare(expected_with_bc + [
+          'junit/junit/4.12/junit-4.12.jar',
+          'org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar',
+          'org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar'
+        ])
 
       _(Helper.prepare(subject.classpath_string(:runtime).split(File::PATH_SEPARATOR)))
-            .must_equal Helper.prepare(example_expected)
+        .must_equal Helper.prepare(example_expected)
     end
   end
 

--- a/specs/jar_installer_spec.rb
+++ b/specs/jar_installer_spec.rb
@@ -44,7 +44,7 @@ describe Jars::Installer do
     File.read(jars).each_line do |line|
       _(line).must_match(/^\s{2}require(_jar)?\s'.+'$/) if line.size > 30 && !line.match(/^#/)
     end
-    _( Dir[File.join(dir, '**')].size ).must_equal 1
+    _(Dir[File.join(dir, '**')].size).must_equal 1
   end
 
   it 'generates vendored require-file' do
@@ -54,7 +54,7 @@ describe Jars::Installer do
     File.read(jars).each_line do |line|
       _(line).must_match(/^\s{2}require(_jar)?\s'.+'$/) if line.size > 30 && !line.match(/^#/)
     end
-    _( Dir[File.join(dir, '**', '*.jar')].size ).must_equal 45
+    _(Dir[File.join(dir, '**', '*.jar')].size).must_equal 45
   end
 
   it 'just skips install_jars and vendor_jars if there are no requirements' do

--- a/specs/jars_spec.rb
+++ b/specs/jars_spec.rb
@@ -165,7 +165,7 @@ describe Jars do
     begin
       $stderr = StringIO.new
 
-      -> { require_jar('org.slf4j', 'slf4j-simple', '1.6.6') }.must_raise RuntimeError
+      _ { require_jar('org.slf4j', 'slf4j-simple', '1.6.6') }.must_raise RuntimeError
 
       $stderr.flush
 
@@ -246,7 +246,6 @@ describe Jars do
     load File.expand_path('lib/jar_dependencies.rb')
 
     _($stderr.string).must_equal ''
-
   ensure
     $stderr = STDERR
   end
@@ -267,7 +266,6 @@ describe Jars do
     _($stderr.string).must_match(/omit version 2/)
     _($stderr.string).must_match(/omit version 3/)
     _($stderr.string).wont_match(/omit version 4/)
-
   ensure
     $stderr = STDERR
 


### PR DESCRIPTION
Address failures from #96 due to changes in JRuby patch releases since that PR was created (10.0.3 -> 10.0.4 removed gems that shouldn't have been included in JRuby 10 for strict ruby 3.4 compat)

Old rubycop doesnt require base64, as needed on Ruby 3.4. New rubocop doesn't support running on JRuby 9.3/ruby 2.6, but can target the syntax.

As a static analysis tool, we don't need to actually run rubocop on older JRuby runtime, just ensure compatibility with JRuby 9.3 which can be addressed via .rubocop.yml target syntax. PR thus only runs rubocop vis latest jruby in the matrix.