### PR TITLE
Revert "Depend on ruby-maven at runtime"

### DIFF
--- a/jar-dependencies.gemspec
+++ b/jar-dependencies.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6'
 
   s.add_development_dependency 'minitest', '~> 5.10'
-  s.add_dependency 'ruby-maven', ruby_maven_version = '~> 3.9'
+  s.add_development_dependency 'ruby-maven', ruby_maven_version = '~> 3.9'
 
   s.post_install_message = <<~TEXT
 


### PR DESCRIPTION
Reverts jruby/jar-dependencies#98

The increased size of this hard dependency is not acceptable, since jar-dependencies is used by many libraries (including the heavily-used core library `psych`. We will explore other options and I will patch around the issue in stringio for now.