### PR TITLE
Remove jars and rig build to ensure they are downloaded

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,32 +21,8 @@ require_relative 'lib/jars/mima/version'
 
 MIMA_VERSION = Jars::Mima::MIMA_VERSION
 SLF4J_VERSION = Jars::Mima::SLF4J_VERSION
-MAVEN_CENTRAL = 'https://repo.maven.apache.org/maven2'
-MIMA_DIR = 'lib/jars/mima'
-
-# URL and SHA-1 checksum (as published on Maven Central) for each jar
-MIMA_JARS = {
-  "slf4j-api-#{SLF4J_VERSION}.jar" => {
-    url: "#{MAVEN_CENTRAL}/org/slf4j/slf4j-api/#{SLF4J_VERSION}/slf4j-api-#{SLF4J_VERSION}.jar",
-    sha1: '6c62681a2f655b49963a5983b8b0950a6120ae14'
-  },
-  "slf4j-simple-#{SLF4J_VERSION}.jar" => {
-    url: "#{MAVEN_CENTRAL}/org/slf4j/slf4j-simple/#{SLF4J_VERSION}/slf4j-simple-#{SLF4J_VERSION}.jar",
-    sha1: 'a41f9cfe6faafb2eb83a1c7dd2d0dfd844e2a936'
-  },
-  "jcl-over-slf4j-#{SLF4J_VERSION}.jar" => {
-    url: "#{MAVEN_CENTRAL}/org/slf4j/jcl-over-slf4j/#{SLF4J_VERSION}/jcl-over-slf4j-#{SLF4J_VERSION}.jar",
-    sha1: 'd877e195a05aca4a2f1ad2ff14bfec1393af4b5e'
-  },
-  "context-#{MIMA_VERSION}.jar" => {
-    url: "#{MAVEN_CENTRAL}/eu/maveniverse/maven/mima/context/#{MIMA_VERSION}/context-#{MIMA_VERSION}.jar",
-    sha1: '72aa4d9ccef7a329f473e43752ec863c5194c72c'
-  },
-  "standalone-static-uber-#{MIMA_VERSION}.jar" => {
-    url: "#{MAVEN_CENTRAL}/eu/maveniverse/maven/mima/runtime/standalone-static-uber/#{MIMA_VERSION}/standalone-static-uber-#{MIMA_VERSION}.jar",
-    sha1: '43666099e6eb31610f9d3b146811479dd3e4aef1'
-  }
-}.freeze
+MIMA_JARS = Jars::Mima::JARS
+MIMA_DIR = Jars::Mima::MIMA_DIR
 
 MIMA_JARS.each_key { |jar| CLEAN.include(File.join(MIMA_DIR, jar)) }
 

--- a/jar-dependencies.gemspec
+++ b/jar-dependencies.gemspec
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'lib/jars/version'
+require_relative 'lib/jars/mima/version'
 
 Gem::Specification.new do |s|
   s.name = 'jar-dependencies'
@@ -18,6 +19,8 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.files = Dir['{lib}/**/*'] + %w[Mavenfile Rakefile Readme.md jar-dependencies.gemspec MIT-LICENSE]
+  # explicitly require the jars
+  s.files += Jars::Mima::JARS.each_key.map {File.join(Jars::Mima::MIMA_DIR, _1)}
 
   s.description = <<~TEXT
     manage jar dependencies for gems and keep track which jar was already

--- a/lib/jars/mima/version.rb
+++ b/lib/jars/mima/version.rb
@@ -8,28 +8,35 @@ module Jars
     MAVEN_CENTRAL = 'https://repo.maven.apache.org/maven2'
     MIMA_DIR = 'lib/jars/mima'
 
-    # URL and SHA-1 checksum (as published on Maven Central) for each jar
-    JARS = {
-      "slf4j-api-#{SLF4J_VERSION}.jar" => {
-        url: "#{MAVEN_CENTRAL}/org/slf4j/slf4j-api/#{SLF4J_VERSION}/slf4j-api-#{SLF4J_VERSION}.jar",
-        sha1: 'd9e58ac9c7779ba3bf8142aff6c830617a7fe60f'
-      },
-      "slf4j-simple-#{SLF4J_VERSION}.jar" => {
-        url: "#{MAVEN_CENTRAL}/org/slf4j/slf4j-simple/#{SLF4J_VERSION}/slf4j-simple-#{SLF4J_VERSION}.jar",
-        sha1: '9872a3fd794ffe7b18d17747926a64d61526ca96'
-      },
-      "jcl-over-slf4j-#{SLF4J_VERSION}.jar" => {
-        url: "#{MAVEN_CENTRAL}/org/slf4j/jcl-over-slf4j/#{SLF4J_VERSION}/jcl-over-slf4j-#{SLF4J_VERSION}.jar",
-        sha1: '76ea503eb688f06556a9ba69995d7eab63e34531'
-      },
-      "context-#{MIMA_VERSION}.jar" => {
-        url: "#{MAVEN_CENTRAL}/eu/maveniverse/maven/mima/context/#{MIMA_VERSION}/context-#{MIMA_VERSION}.jar",
-        sha1: '72aa4d9ccef7a329f473e43752ec863c5194c72c'
-      },
-      "standalone-static-uber-#{MIMA_VERSION}.jar" => {
-        url: "#{MAVEN_CENTRAL}/eu/maveniverse/maven/mima/runtime/standalone-static-uber/#{MIMA_VERSION}/standalone-static-uber-#{MIMA_VERSION}.jar",
-        sha1: '43666099e6eb31610f9d3b146811479dd3e4aef1'
-      }
-    }.freeze
+    # GAV and SHA-1 checksum (as published on Maven Central) for each jar
+    jars = %w[
+      org.slf4j:slf4j-api:2.0.17
+      d9e58ac9c7779ba3bf8142aff6c830617a7fe60f
+
+      org.slf4j:slf4j-simple:2.0.17
+      9872a3fd794ffe7b18d17747926a64d61526ca96
+
+      org.slf4j:jcl-over-slf4j:2.0.17
+      76ea503eb688f06556a9ba69995d7eab63e34531
+
+      eu.maveniverse.maven.mima:context:2.4.42
+      72aa4d9ccef7a329f473e43752ec863c5194c72c
+
+      eu.maveniverse.maven.mima.runtime:standalone-static-uber:2.4.42
+      43666099e6eb31610f9d3b146811479dd3e4aef1
+    ]
+
+    JARS = jars.each_slice(2).to_h do |gav, sha1|
+      group, artifact, version = gav.split(':')
+      group = group.tr('.', '/')
+      jar_file = "#{artifact}-#{version}.jar"
+      [
+        jar_file,
+        {
+          url: "#{MAVEN_CENTRAL}/#{group}/#{artifact}/#{version}/#{jar_file}",
+          sha1: sha1
+        }
+      ]
+    end
   end
 end

--- a/lib/jars/mima/version.rb
+++ b/lib/jars/mima/version.rb
@@ -3,6 +3,33 @@
 module Jars
   module Mima
     MIMA_VERSION = '2.4.42'
-    SLF4J_VERSION = '1.7.36'
+    SLF4J_VERSION = '2.0.17'
+
+    MAVEN_CENTRAL = 'https://repo.maven.apache.org/maven2'
+    MIMA_DIR = 'lib/jars/mima'
+
+    # URL and SHA-1 checksum (as published on Maven Central) for each jar
+    JARS = {
+      "slf4j-api-#{SLF4J_VERSION}.jar" => {
+        url: "#{MAVEN_CENTRAL}/org/slf4j/slf4j-api/#{SLF4J_VERSION}/slf4j-api-#{SLF4J_VERSION}.jar",
+        sha1: 'd9e58ac9c7779ba3bf8142aff6c830617a7fe60f'
+      },
+      "slf4j-simple-#{SLF4J_VERSION}.jar" => {
+        url: "#{MAVEN_CENTRAL}/org/slf4j/slf4j-simple/#{SLF4J_VERSION}/slf4j-simple-#{SLF4J_VERSION}.jar",
+        sha1: '9872a3fd794ffe7b18d17747926a64d61526ca96'
+      },
+      "jcl-over-slf4j-#{SLF4J_VERSION}.jar" => {
+        url: "#{MAVEN_CENTRAL}/org/slf4j/jcl-over-slf4j/#{SLF4J_VERSION}/jcl-over-slf4j-#{SLF4J_VERSION}.jar",
+        sha1: '76ea503eb688f06556a9ba69995d7eab63e34531'
+      },
+      "context-#{MIMA_VERSION}.jar" => {
+        url: "#{MAVEN_CENTRAL}/eu/maveniverse/maven/mima/context/#{MIMA_VERSION}/context-#{MIMA_VERSION}.jar",
+        sha1: '72aa4d9ccef7a329f473e43752ec863c5194c72c'
+      },
+      "standalone-static-uber-#{MIMA_VERSION}.jar" => {
+        url: "#{MAVEN_CENTRAL}/eu/maveniverse/maven/mima/runtime/standalone-static-uber/#{MIMA_VERSION}/standalone-static-uber-#{MIMA_VERSION}.jar",
+        sha1: '43666099e6eb31610f9d3b146811479dd3e4aef1'
+      }
+    }.freeze
   end
 end


### PR DESCRIPTION
* Remove all the jars from the repo; we should not version them.
* Move the list of jar URLs and SHA1s to a library constant.
* Use the list to ensure they are present before building the gem.