### PR TITLE
re-invent a form of debug logging via JARS_DEBUG=true

### DIFF
--- a/lib/jars/mima.rb
+++ b/lib/jars/mima.rb
@@ -108,9 +108,7 @@ module Jars
         result = context.repositorySystem.resolveDependencies(
           context.repositorySystemSession, dependency_request
         )
-
-        root = result.getRoot
-        collect_resolved(root)
+        collect_resolved(result.getRoot)
       end
 
       private
@@ -131,27 +129,27 @@ module Jars
         Java::org.eclipse.aether.RepositoryListener.impl do |method, event|
           case method
           when :artifactDescriptorInvalid
-            Jars.debug { "[mima] invalid artifact descriptor #{Jars::Mima.send(:artifact_label, event.getArtifact)}" }
+            Jars.debug { "[mima] invalid artifact descriptor #{artifact_label(event.getArtifact)}" }
           when :artifactDescriptorMissing
-            Jars.debug { "[mima] missing artifact descriptor #{Jars::Mima.send(:artifact_label, event.getArtifact)}" }
+            Jars.debug { "[mima] missing artifact descriptor #{artifact_label(event.getArtifact)}" }
           when :metadataInvalid
-            Jars.debug { "[mima] invalid metadata #{Jars::Mima.send(:metadata_label, event.getMetadata)}" }
+            Jars.debug { "[mima] invalid metadata #{metadata_label(event.getMetadata)}" }
           when :artifactResolving
-            Jars.debug { "[mima] resolving artifact #{Jars::Mima.send(:artifact_label, event.getArtifact)}" }
+            Jars.debug { "[mima] resolving artifact #{artifact_label(event.getArtifact)}" }
           when :artifactResolved
-            Jars.debug { Jars::Mima.send(:resolved_message, 'artifact', event) }
+            Jars.debug { resolved_message('artifact', event) }
           when :metadataResolving
-            Jars.debug { "[mima] resolving metadata #{Jars::Mima.send(:metadata_label, event.getMetadata)}" }
+            Jars.debug { "[mima] resolving metadata #{metadata_label(event.getMetadata)}" }
           when :metadataResolved
-            Jars.debug { Jars::Mima.send(:resolved_message, 'metadata', event) }
+            Jars.debug { resolved_message('metadata', event) }
           when :artifactDownloading
-            Jars.debug { Jars::Mima.send(:download_message, 'artifact', event) }
+            Jars.debug { download_message('artifact', event) }
           when :artifactDownloaded
-            Jars.debug { Jars::Mima.send(:downloaded_message, 'artifact', event) }
+            Jars.debug { downloaded_message('artifact', event) }
           when :metadataDownloading
-            Jars.debug { Jars::Mima.send(:download_message, 'metadata', event) }
+            Jars.debug { download_message('metadata', event) }
           when :metadataDownloaded
-            Jars.debug { Jars::Mima.send(:downloaded_message, 'metadata', event) }
+            Jars.debug { downloaded_message('metadata', event) }
           end
         end
       end
@@ -160,15 +158,15 @@ module Jars
         Java::org.eclipse.aether.transfer.TransferListener.impl do |method, event|
           case method
           when :transferInitiated
-            Jars.debug { Jars::Mima.send(:transfer_message, 'initiated', event) }
+            Jars.debug { transfer_message('initiated', event) }
           when :transferStarted
-            Jars.debug { Jars::Mima.send(:transfer_message, 'started', event) }
+            Jars.debug { transfer_message('started', event) }
           when :transferCorrupted
-            Jars.debug { Jars::Mima.send(:transfer_message, 'corrupted', event) }
+            Jars.debug { transfer_message('corrupted', event) }
           when :transferSucceeded
-            Jars.debug { Jars::Mima.send(:transfer_message, 'succeeded', event, bytes: true) }
+            Jars.debug { transfer_message('succeeded', event, bytes: true) }
           when :transferFailed
-            Jars.debug { Jars::Mima.send(:transfer_message, 'failed', event) }
+            Jars.debug { transfer_message('failed', event) }
           end
         end
       end
@@ -202,11 +200,11 @@ module Jars
       end
 
       def artifact_label(artifact)
-        artifact ? artifact.toString : 'unknown'
+        artifact&.to_s || 'unknown'
       end
 
       def metadata_label(metadata)
-        metadata ? metadata.toString : 'unknown'
+        metadata&.to_s || 'unknown'
       end
 
       def transfer_message(action, event, bytes: false)

--- a/lib/jars/mima.rb
+++ b/lib/jars/mima.rb
@@ -52,11 +52,8 @@ module Jars
         global = ::Jars::MavenSettings.global_settings
         builder.withGlobalSettingsXmlOverride(java.nio.file.Paths.get(global)) if global
 
-        if Jars.debug?
-          builder.repositoryListener(debug_repository_listener)
-          builder.transferListener(debug_transfer_listener)
-        end
-
+        builder.repositoryListener(aether_repository_listener)
+        builder.transferListener(aether_transfer_listener)
         builder.build
       end
 
@@ -125,8 +122,8 @@ module Jars
         ENV_JAVA[key] = value unless ENV_JAVA[key]
       end
 
-      def debug_repository_listener
-        Java::org.eclipse.aether.RepositoryListener.impl do |method, event|
+      def aether_repository_listener
+        org.eclipse.aether.RepositoryListener.impl do |method, event|
           case method
           when :artifactDescriptorInvalid
             Jars.debug { "[mima] invalid artifact descriptor #{artifact_label(event.getArtifact)}" }
@@ -154,8 +151,8 @@ module Jars
         end
       end
 
-      def debug_transfer_listener
-        Java::org.eclipse.aether.transfer.TransferListener.impl do |method, event|
+      def aether_transfer_listener
+        org.eclipse.aether.transfer.TransferListener.impl do |method, event|
           case method
           when :transferInitiated
             Jars.debug { transfer_message('initiated', event) }
@@ -229,17 +226,17 @@ module Jars
       # @param all_dependencies [Boolean]
       # @return [Array<org.eclipse.aether.graph.Dependency>]
       def artifacts_to_dependencies(artifacts, all_dependencies: false)
-        filtered = artifacts.select do |a|
-          all_dependencies || (a.scope != 'provided' && a.scope != 'test')
+        filtered_artifacts = artifacts.select do |artifact|
+          all_dependencies || (artifact.scope != 'provided' && artifact.scope != 'test')
         end
 
-        filtered.map do |a|
-          aether_artifact = build_aether_artifact(a)
-          scope = a.scope || 'compile'
+        filtered_artifacts.map do |artifact|
+          aether_artifact = build_aether_artifact(artifact)
+          scope = artifact.scope || 'compile'
           dep = org.eclipse.aether.graph.Dependency.new(aether_artifact, scope)
 
-          if a.exclusions && !a.exclusions.empty?
-            exclusions = a.exclusions.map do |ex|
+          if artifact.exclusions && !artifact.exclusions.empty?
+            exclusions = artifact.exclusions.map do |ex|
               org.eclipse.aether.graph.Exclusion.new(ex.group_id, ex.artifact_id, '*', '*')
             end
             dep = dep.setExclusions(exclusions)

--- a/lib/jars/mima.rb
+++ b/lib/jars/mima.rb
@@ -17,6 +17,8 @@ module Jars
       def ensure_jars_loaded
         return if @@jars_loaded
 
+        configure_logging if Jars.debug?
+
         mima_dir = File.expand_path('mima', File.dirname(__FILE__))
 
         load File.join(mima_dir, "slf4j-api-#{SLF4J_VERSION}.jar")
@@ -49,6 +51,11 @@ module Jars
         # Global settings.xml override
         global = ::Jars::MavenSettings.global_settings
         builder.withGlobalSettingsXmlOverride(java.nio.file.Paths.get(global)) if global
+
+        if Jars.debug?
+          builder.repositoryListener(debug_repository_listener)
+          builder.transferListener(debug_transfer_listener)
+        end
 
         builder.build
       end
@@ -107,6 +114,115 @@ module Jars
       end
 
       private
+
+      def configure_logging
+        return unless Object.const_defined?(:ENV_JAVA)
+
+        set_default_java_property('org.slf4j.simpleLogger.defaultLogLevel', 'info')
+        set_default_java_property('org.slf4j.simpleLogger.showThreadName', 'false')
+        set_default_java_property('org.slf4j.simpleLogger.log.org.apache.maven', 'debug')
+      end
+
+      def set_default_java_property(key, value)
+        ENV_JAVA[key] = value unless ENV_JAVA[key]
+      end
+
+      def debug_repository_listener
+        Java::org.eclipse.aether.RepositoryListener.impl do |method, event|
+          case method
+          when :artifactDescriptorInvalid
+            Jars.debug { "[mima] invalid artifact descriptor #{Jars::Mima.send(:artifact_label, event.getArtifact)}" }
+          when :artifactDescriptorMissing
+            Jars.debug { "[mima] missing artifact descriptor #{Jars::Mima.send(:artifact_label, event.getArtifact)}" }
+          when :metadataInvalid
+            Jars.debug { "[mima] invalid metadata #{Jars::Mima.send(:metadata_label, event.getMetadata)}" }
+          when :artifactResolving
+            Jars.debug { "[mima] resolving artifact #{Jars::Mima.send(:artifact_label, event.getArtifact)}" }
+          when :artifactResolved
+            Jars.debug { Jars::Mima.send(:resolved_message, 'artifact', event) }
+          when :metadataResolving
+            Jars.debug { "[mima] resolving metadata #{Jars::Mima.send(:metadata_label, event.getMetadata)}" }
+          when :metadataResolved
+            Jars.debug { Jars::Mima.send(:resolved_message, 'metadata', event) }
+          when :artifactDownloading
+            Jars.debug { Jars::Mima.send(:download_message, 'artifact', event) }
+          when :artifactDownloaded
+            Jars.debug { Jars::Mima.send(:downloaded_message, 'artifact', event) }
+          when :metadataDownloading
+            Jars.debug { Jars::Mima.send(:download_message, 'metadata', event) }
+          when :metadataDownloaded
+            Jars.debug { Jars::Mima.send(:downloaded_message, 'metadata', event) }
+          end
+        end
+      end
+
+      def debug_transfer_listener
+        Java::org.eclipse.aether.transfer.TransferListener.impl do |method, event|
+          case method
+          when :transferInitiated
+            Jars.debug { Jars::Mima.send(:transfer_message, 'initiated', event) }
+          when :transferStarted
+            Jars.debug { Jars::Mima.send(:transfer_message, 'started', event) }
+          when :transferCorrupted
+            Jars.debug { Jars::Mima.send(:transfer_message, 'corrupted', event) }
+          when :transferSucceeded
+            Jars.debug { Jars::Mima.send(:transfer_message, 'succeeded', event, bytes: true) }
+          when :transferFailed
+            Jars.debug { Jars::Mima.send(:transfer_message, 'failed', event) }
+          end
+        end
+      end
+
+      def resolved_message(kind, event)
+        message = +"[mima] resolved #{kind} #{repository_item_label(event)}"
+        message << " -> #{event.getFile.getAbsolutePath}" if event.getFile
+        message << " (#{event.getException.message})" if event.getException
+        message
+      end
+
+      def download_message(kind, event)
+        message = +"[mima] downloading #{kind} #{repository_item_label(event)}"
+        repository = event.getRepository
+        message << " from #{repository}" if repository
+        message
+      end
+
+      def downloaded_message(kind, event)
+        message = +"[mima] downloaded #{kind} #{repository_item_label(event)}"
+        message << " -> #{event.getFile.getAbsolutePath}" if event.getFile
+        message << " (#{event.getException.message})" if event.getException
+        message
+      end
+
+      def repository_item_label(event)
+        artifact = event.getArtifact
+        return artifact_label(artifact) if artifact
+
+        metadata_label(event.getMetadata)
+      end
+
+      def artifact_label(artifact)
+        artifact ? artifact.toString : 'unknown'
+      end
+
+      def metadata_label(metadata)
+        metadata ? metadata.toString : 'unknown'
+      end
+
+      def transfer_message(action, event, bytes: false)
+        resource = event.getResource
+        location = "#{resource.getRepositoryUrl}#{resource.getResourceName}"
+        message = +"[mima] transfer #{action} #{event.getRequestType.to_s.downcase} #{location}"
+        message << " (#{format_bytes(event.getTransferredBytes)})" if bytes
+        message << " (#{event.getException})" if event.getException
+        message
+      end
+
+      def format_bytes(bytes)
+        return "#{bytes} B" if bytes < 1024
+
+        "#{(bytes / 1024.0).round(1)} KB"
+      end
 
       # Converts {GemspecArtifacts::Artifact} objects to Aether +Dependency+ list,
       # filtering by scope unless +all_dependencies+ is set.

--- a/specs/mima_spec.rb
+++ b/specs/mima_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require File.expand_path('setup', File.dirname(__FILE__))
+
+require 'jars/mima'
+require 'stringio'
+
+describe Jars::Mima do
+  before do
+    @env = ENV.to_h
+    @properties = %w[
+      org.slf4j.simpleLogger.defaultLogLevel
+      org.slf4j.simpleLogger.showThreadName
+      org.slf4j.simpleLogger.log.org.apache.maven
+    ]
+    @previous = @properties.to_h { |property| [property, ENV_JAVA[property]] }
+    @properties.each { |property| ENV_JAVA[property] = nil }
+    Jars.reset
+  end
+
+  after do
+    @previous.each { |property, value| ENV_JAVA[property] = value } if @previous
+    ENV.replace @env if @env
+    Jars.reset
+  end
+
+  it 'produces debug output from debug listeners' do
+    ENV['JARS_DEBUG'] = 'true'
+    $stderr = StringIO.new
+    context = Jars::Mima.create_context
+
+    artifact = org.eclipse.aether.artifact.DefaultArtifact.new('org.example', 'example', 'jar', '1.0')
+    event_type = org.eclipse.aether.RepositoryEvent::EventType::ARTIFACT_RESOLVING
+    event = org.eclipse.aether.RepositoryEvent::Builder.new(context.repositorySystemSession,
+                                                            event_type).setArtifact(artifact).build
+
+    Jars::Mima.send(:debug_repository_listener).artifactResolving(event)
+
+    _($stderr.string).must_include '[mima] resolving artifact org.example:example:jar:1.0'
+  ensure
+    context&.close
+    $stderr = STDERR
+  end
+end

--- a/specs/mima_spec.rb
+++ b/specs/mima_spec.rb
@@ -27,18 +27,16 @@ describe Jars::Mima do
   it 'produces debug output from debug listeners' do
     ENV['JARS_DEBUG'] = 'true'
     $stderr = StringIO.new
-    context = Jars::Mima.create_context
 
-    artifact = org.eclipse.aether.artifact.DefaultArtifact.new('org.example', 'example', 'jar', '1.0')
-    event_type = org.eclipse.aether.RepositoryEvent::EventType::ARTIFACT_RESOLVING
-    event = org.eclipse.aether.RepositoryEvent::Builder.new(context.repositorySystemSession,
-                                                            event_type).setArtifact(artifact).build
-
-    Jars::Mima.send(:debug_repository_listener).artifactResolving(event)
+    artifact = Jars::GemspecArtifacts::Artifact.new('jar org.example:example, 1.0')
+    begin
+      Jars::Mima.resolve_artifacts([ artifact ])
+    rescue org.eclipse.aether.resolution.DependencyResolutionException
+      # expected
+    end
 
     _($stderr.string).must_include '[mima] resolving artifact org.example:example:jar:1.0'
   ensure
-    context&.close
     $stderr = STDERR
   end
 end


### PR DESCRIPTION
one of the things we lost switching to Mima (https://github.com/jruby/jar-dependencies/pull/102)

old logging example: https://gist.github.com/kares/5186c2d792bf6032cc04c431b88cc1f9

this new logging isn't that detailed but hopefully still quite useful:
```
JARS_DEBUG=true ruby -Ilib -rjar_dependencies -S gem install psych
--- loaded jars ---
	
jar registration: ["org.bouncycastle", "bcprov-jdk18on", "1.84"]; loaded=true
jar registration: ["org.bouncycastle", "bcpkix-jdk18on", "1.84"]; loaded=true
jar registration: ["org.bouncycastle", "bcutil-jdk18on", "1.84"]; loaded=true
jar registration: ["org.bouncycastle", "bctls-jdk18on", "1.84"]; loaded=true
jar registration: ["org.snakeyaml", "snakeyaml-engine", "2.10"]; loaded=true
Fetching psych-5.4.0-java.gem
  jar dependencies for psych-5.4.0-java.gemspec . . .
[mima] resolving artifact org.snakeyaml:snakeyaml-engine:pom:2.10
[mima] downloading artifact org.snakeyaml:snakeyaml-engine:pom:2.10 from central (https://repo.maven.apache.org/maven2/, default, releases)
[mima] transfer initiated get https://repo.maven.apache.org/maven2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.pom
[mima] transfer started get https://repo.maven.apache.org/maven2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.pom
[mima] transfer succeeded get https://repo.maven.apache.org/maven2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.pom (22.6 KB)
[mima] downloaded artifact org.snakeyaml:snakeyaml-engine:pom:2.10 -> /home/kares/.m2/repository/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.pom
[mima] resolved artifact org.snakeyaml:snakeyaml-engine:pom:2.10 -> /home/kares/.m2/repository/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.pom
[mima] resolving artifact org.snakeyaml:snakeyaml-engine:jar:2.10
[mima] downloading artifact org.snakeyaml:snakeyaml-engine:jar:2.10 from central (https://repo.maven.apache.org/maven2/, default, releases)
[mima] transfer initiated get https://repo.maven.apache.org/maven2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.jar
[mima] transfer started get https://repo.maven.apache.org/maven2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.jar
[mima] transfer succeeded get https://repo.maven.apache.org/maven2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.jar (293.0 KB)
[mima] downloaded artifact org.snakeyaml:snakeyaml-engine:jar:2.10 -> /home/kares/.m2/repository/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.jar
[mima] resolved artifact org.snakeyaml:snakeyaml-engine:jar:2.10 -> /home/kares/.m2/repository/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.jar
Successfully installed psych-5.4.0-java
1 gem installed
```